### PR TITLE
Fresh schema / data dumps with pg11 pg_dump. Also switch to UTF8 data.

### DIFF
--- a/pagila-data.sql
+++ b/pagila-data.sql
@@ -2,19 +2,19 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10beta4
--- Dumped by pg_dump version 10beta4
+-- Dumped from database version 11.3
+-- Dumped by pg_dump version 11.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
-SET search_path = public, pg_catalog;
 
 --
 -- Data for Name: actor; Type: TABLE DATA; Schema: public; Owner: postgres
@@ -22,9 +22,9 @@ SET search_path = public, pg_catalog;
 
 SET SESSION AUTHORIZATION DEFAULT;
 
-ALTER TABLE actor DISABLE TRIGGER ALL;
+ALTER TABLE public.actor DISABLE TRIGGER ALL;
 
-COPY actor (actor_id, first_name, last_name, last_update) FROM stdin;
+COPY public.actor (actor_id, first_name, last_name, last_update) FROM stdin;
 1	PENELOPE	GUINESS	2006-02-15 09:34:33
 2	NICK	WAHLBERG	2006-02-15 09:34:33
 3	ED	CHASE	2006-02-15 09:34:33
@@ -228,15 +228,15 @@ COPY actor (actor_id, first_name, last_name, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE actor ENABLE TRIGGER ALL;
+ALTER TABLE public.actor ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: country; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE country DISABLE TRIGGER ALL;
+ALTER TABLE public.country DISABLE TRIGGER ALL;
 
-COPY country (country_id, country, last_update) FROM stdin;
+COPY public.country (country_id, country, last_update) FROM stdin;
 1	Afghanistan	2006-02-15 09:44:00
 2	Algeria	2006-02-15 09:44:00
 3	American Samoa	2006-02-15 09:44:00
@@ -349,15 +349,15 @@ COPY country (country_id, country, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE country ENABLE TRIGGER ALL;
+ALTER TABLE public.country ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: city; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE city DISABLE TRIGGER ALL;
+ALTER TABLE public.city DISABLE TRIGGER ALL;
 
-COPY city (city_id, city, country_id, last_update) FROM stdin;
+COPY public.city (city_id, city, country_id, last_update) FROM stdin;
 1	A Corua (La Corua)	87	2006-02-15 09:45:25
 2	Abha	82	2006-02-15 09:45:25
 3	Abu Dhabi	101	2006-02-15 09:45:25
@@ -961,15 +961,15 @@ COPY city (city_id, city, country_id, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE city ENABLE TRIGGER ALL;
+ALTER TABLE public.city ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: address; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE address DISABLE TRIGGER ALL;
+ALTER TABLE public.address DISABLE TRIGGER ALL;
 
-COPY address (address_id, address, address2, district, city_id, postal_code, phone, last_update) FROM stdin;
+COPY public.address (address_id, address, address2, district, city_id, postal_code, phone, last_update) FROM stdin;
 1	47 MySakila Drive	\N	Alberta	300			2006-02-15 09:45:30
 2	28 MySQL Boulevard	\N	QLD	576			2006-02-15 09:45:30
 3	23 Workhaven Lane	\N	Alberta	300		14033335568	2006-02-15 09:45:30
@@ -1576,15 +1576,15 @@ COPY address (address_id, address, address2, district, city_id, postal_code, pho
 \.
 
 
-ALTER TABLE address ENABLE TRIGGER ALL;
+ALTER TABLE public.address ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: category; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE category DISABLE TRIGGER ALL;
+ALTER TABLE public.category DISABLE TRIGGER ALL;
 
-COPY category (category_id, name, last_update) FROM stdin;
+COPY public.category (category_id, name, last_update) FROM stdin;
 1	Action	2006-02-15 09:46:27
 2	Animation	2006-02-15 09:46:27
 3	Children	2006-02-15 09:46:27
@@ -1604,43 +1604,43 @@ COPY category (category_id, name, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE category ENABLE TRIGGER ALL;
+ALTER TABLE public.category ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: staff; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE staff DISABLE TRIGGER ALL;
+ALTER TABLE public.staff DISABLE TRIGGER ALL;
 
-COPY staff (staff_id, first_name, last_name, address_id, email, store_id, active, username, password, last_update, picture) FROM stdin;
+COPY public.staff (staff_id, first_name, last_name, address_id, email, store_id, active, username, password, last_update, picture) FROM stdin;
 1	Mike	Hillyer	3	Mike.Hillyer@sakilastaff.com	1	t	Mike	8cb2237d0679ca88db6464eac60da96345513964	2006-05-16 16:13:11.79328	\\x89504e470d0a5a0a
 2	Jon	Stephens	4	Jon.Stephens@sakilastaff.com	2	t	Jon	8cb2237d0679ca88db6464eac60da96345513964	2006-05-16 16:13:11.79328	\N
 \.
 
 
-ALTER TABLE staff ENABLE TRIGGER ALL;
+ALTER TABLE public.staff ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: store; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE store DISABLE TRIGGER ALL;
+ALTER TABLE public.store DISABLE TRIGGER ALL;
 
-COPY store (store_id, manager_staff_id, address_id, last_update) FROM stdin;
+COPY public.store (store_id, manager_staff_id, address_id, last_update) FROM stdin;
 1	1	1	2006-02-15 09:57:12
 2	2	2	2006-02-15 09:57:12
 \.
 
 
-ALTER TABLE store ENABLE TRIGGER ALL;
+ALTER TABLE public.store ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: customer; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE customer DISABLE TRIGGER ALL;
+ALTER TABLE public.customer DISABLE TRIGGER ALL;
 
-COPY customer (customer_id, store_id, first_name, last_name, email, address_id, activebool, create_date, last_update, active) FROM stdin;
+COPY public.customer (customer_id, store_id, first_name, last_name, email, address_id, activebool, create_date, last_update, active) FROM stdin;
 1	1	MARY	SMITH	MARY.SMITH@sakilacustomer.org	5	t	2006-02-14	2006-02-15 09:57:20	1
 2	1	PATRICIA	JOHNSON	PATRICIA.JOHNSON@sakilacustomer.org	6	t	2006-02-14	2006-02-15 09:57:20	1
 3	1	LINDA	WILLIAMS	LINDA.WILLIAMS@sakilacustomer.org	7	t	2006-02-14	2006-02-15 09:57:20	1
@@ -2243,15 +2243,15 @@ COPY customer (customer_id, store_id, first_name, last_name, email, address_id, 
 \.
 
 
-ALTER TABLE customer ENABLE TRIGGER ALL;
+ALTER TABLE public.customer ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: language; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE language DISABLE TRIGGER ALL;
+ALTER TABLE public.language DISABLE TRIGGER ALL;
 
-COPY language (language_id, name, last_update) FROM stdin;
+COPY public.language (language_id, name, last_update) FROM stdin;
 1	English             	2006-02-15 10:02:19
 2	Italian             	2006-02-15 10:02:19
 3	Japanese            	2006-02-15 10:02:19
@@ -2261,15 +2261,15 @@ COPY language (language_id, name, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE language ENABLE TRIGGER ALL;
+ALTER TABLE public.language ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: film; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE film DISABLE TRIGGER ALL;
+ALTER TABLE public.film DISABLE TRIGGER ALL;
 
-COPY film (film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, last_update, special_features, fulltext) FROM stdin;
+COPY public.film (film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, last_update, special_features, fulltext) FROM stdin;
 1	ACADEMY DINOSAUR	A Epic Drama of a Feminist And a Mad Scientist who must Battle a Teacher in The Canadian Rockies	2006	1	\N	6	0.99	86	20.99	PG	2007-09-10 17:46:03.905795	{"Deleted Scenes","Behind the Scenes"}	'academi':1 'battl':15 'canadian':20 'dinosaur':2 'drama':5 'epic':4 'feminist':8 'mad':11 'must':14 'rocki':21 'scientist':12 'teacher':17
 2	ACE GOLDFINGER	A Astounding Epistle of a Database Administrator And a Explorer who must Find a Car in Ancient China	2006	1	\N	3	4.99	48	12.99	G	2007-09-10 17:46:03.905795	{Trailers,"Deleted Scenes"}	'ace':1 'administr':9 'ancient':19 'astound':4 'car':17 'china':20 'databas':8 'epistl':5 'explor':12 'find':15 'goldfing':2 'must':14
 3	ADAPTATION HOLES	A Astounding Reflection of a Lumberjack And a Car who must Sink a Lumberjack in A Baloon Factory	2006	1	\N	7	2.99	50	18.99	NC-17	2007-09-10 17:46:03.905795	{Trailers,"Deleted Scenes"}	'adapt':1 'astound':4 'baloon':19 'car':11 'factori':20 'hole':2 'lumberjack':8,16 'must':13 'reflect':5 'sink':14
@@ -3273,15 +3273,15 @@ COPY film (film_id, title, description, release_year, language_id, original_lang
 \.
 
 
-ALTER TABLE film ENABLE TRIGGER ALL;
+ALTER TABLE public.film ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: film_actor; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE film_actor DISABLE TRIGGER ALL;
+ALTER TABLE public.film_actor DISABLE TRIGGER ALL;
 
-COPY film_actor (actor_id, film_id, last_update) FROM stdin;
+COPY public.film_actor (actor_id, film_id, last_update) FROM stdin;
 1	1	2006-02-15 10:05:03
 1	23	2006-02-15 10:05:03
 1	25	2006-02-15 10:05:03
@@ -8747,15 +8747,15 @@ COPY film_actor (actor_id, film_id, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE film_actor ENABLE TRIGGER ALL;
+ALTER TABLE public.film_actor ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: film_category; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE film_category DISABLE TRIGGER ALL;
+ALTER TABLE public.film_category DISABLE TRIGGER ALL;
 
-COPY film_category (film_id, category_id, last_update) FROM stdin;
+COPY public.film_category (film_id, category_id, last_update) FROM stdin;
 1	6	2006-02-15 10:07:09
 2	11	2006-02-15 10:07:09
 3	6	2006-02-15 10:07:09
@@ -9759,15 +9759,15 @@ COPY film_category (film_id, category_id, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE film_category ENABLE TRIGGER ALL;
+ALTER TABLE public.film_category ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: inventory; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE inventory DISABLE TRIGGER ALL;
+ALTER TABLE public.inventory DISABLE TRIGGER ALL;
 
-COPY inventory (inventory_id, film_id, store_id, last_update) FROM stdin;
+COPY public.inventory (inventory_id, film_id, store_id, last_update) FROM stdin;
 1	1	1	2006-02-15 10:09:17
 2	1	1	2006-02-15 10:09:17
 3	1	1	2006-02-15 10:09:17
@@ -14352,15 +14352,15 @@ COPY inventory (inventory_id, film_id, store_id, last_update) FROM stdin;
 \.
 
 
-ALTER TABLE inventory ENABLE TRIGGER ALL;
+ALTER TABLE public.inventory ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: rental; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE rental DISABLE TRIGGER ALL;
+ALTER TABLE public.rental DISABLE TRIGGER ALL;
 
-COPY rental (rental_id, rental_date, inventory_id, customer_id, return_date, staff_id, last_update) FROM stdin;
+COPY public.rental (rental_id, rental_date, inventory_id, customer_id, return_date, staff_id, last_update) FROM stdin;
 2	2005-05-24 22:54:33	1525	459	2005-05-28 19:40:33	1	2006-02-16 02:30:53
 3	2005-05-24 23:03:39	1711	408	2005-06-01 22:12:39	1	2006-02-16 02:30:53
 4	2005-05-24 23:04:41	2452	333	2005-06-03 01:43:41	2	2006-02-16 02:30:53
@@ -30408,15 +30408,15 @@ COPY rental (rental_id, rental_date, inventory_id, customer_id, return_date, sta
 \.
 
 
-ALTER TABLE rental ENABLE TRIGGER ALL;
+ALTER TABLE public.rental ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_01; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_01 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_01 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_01 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_01 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 16050	269	2	7	1.99	2007-01-24 21:40:19.996577
 16051	269	1	98	0.99	2007-01-25 15:16:50.996577
 16052	269	2	678	6.99	2007-01-28 21:44:14.996577
@@ -31577,15 +31577,15 @@ COPY payment_p2007_01 (payment_id, customer_id, staff_id, rental_id, amount, pay
 \.
 
 
-ALTER TABLE payment_p2007_01 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_01 ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_02; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_02 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_02 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_02 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_02 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 17207	268	1	1394	2.99	2007-02-15 14:45:47.996577
 17208	268	2	1450	4.99	2007-02-15 17:50:34.996577
 17209	268	2	1551	3.99	2007-02-16 00:29:41.996577
@@ -33901,15 +33901,15 @@ COPY payment_p2007_02 (payment_id, customer_id, staff_id, rental_id, amount, pay
 \.
 
 
-ALTER TABLE payment_p2007_02 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_02 ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_03; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_03 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_03 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_03 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_03 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 19519	267	1	10343	2.99	2007-03-01 03:44:13.996577
 19520	267	2	11373	0.99	2007-03-02 16:42:38.996577
 19521	267	1	11690	6.99	2007-03-17 05:12:48.996577
@@ -39557,15 +39557,15 @@ COPY payment_p2007_03 (payment_id, customer_id, staff_id, rental_id, amount, pay
 \.
 
 
-ALTER TABLE payment_p2007_03 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_03 ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_04; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_04 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_04 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_04 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_04 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 25163	267	2	9807	2.99	2007-04-30 09:42:18.996577
 25164	267	2	10048	4.99	2007-04-30 17:37:22.996577
 25165	268	2	3670	4.99	2007-04-06 07:25:09.996577
@@ -46323,15 +46323,15 @@ COPY payment_p2007_04 (payment_id, customer_id, staff_id, rental_id, amount, pay
 \.
 
 
-ALTER TABLE payment_p2007_04 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_04 ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_05; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_05 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_05 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_05 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_05 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 31917	267	2	12066	7.98	2007-05-14 13:44:29.996577
 31918	267	2	13713	0.00	2007-05-14 13:44:29.996577
 31919	269	1	13025	3.98	2007-05-14 13:44:29.996577
@@ -46517,109 +46517,109 @@ COPY payment_p2007_05 (payment_id, customer_id, staff_id, rental_id, amount, pay
 \.
 
 
-ALTER TABLE payment_p2007_05 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_05 ENABLE TRIGGER ALL;
 
 --
 -- Data for Name: payment_p2007_06; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-ALTER TABLE payment_p2007_06 DISABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_06 DISABLE TRIGGER ALL;
 
-COPY payment_p2007_06 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
+COPY public.payment_p2007_06 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) FROM stdin;
 \.
 
 
-ALTER TABLE payment_p2007_06 ENABLE TRIGGER ALL;
+ALTER TABLE public.payment_p2007_06 ENABLE TRIGGER ALL;
 
 --
 -- Name: actor_actor_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('actor_actor_id_seq', 200, true);
+SELECT pg_catalog.setval('public.actor_actor_id_seq', 200, true);
 
 
 --
 -- Name: address_address_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('address_address_id_seq', 605, true);
+SELECT pg_catalog.setval('public.address_address_id_seq', 605, true);
 
 
 --
 -- Name: category_category_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('category_category_id_seq', 16, true);
+SELECT pg_catalog.setval('public.category_category_id_seq', 16, true);
 
 
 --
 -- Name: city_city_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('city_city_id_seq', 600, true);
+SELECT pg_catalog.setval('public.city_city_id_seq', 600, true);
 
 
 --
 -- Name: country_country_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('country_country_id_seq', 109, true);
+SELECT pg_catalog.setval('public.country_country_id_seq', 109, true);
 
 
 --
 -- Name: customer_customer_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('customer_customer_id_seq', 599, true);
+SELECT pg_catalog.setval('public.customer_customer_id_seq', 599, true);
 
 
 --
 -- Name: film_film_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('film_film_id_seq', 1000, true);
+SELECT pg_catalog.setval('public.film_film_id_seq', 1000, true);
 
 
 --
 -- Name: inventory_inventory_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('inventory_inventory_id_seq', 4581, true);
+SELECT pg_catalog.setval('public.inventory_inventory_id_seq', 4581, true);
 
 
 --
 -- Name: language_language_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('language_language_id_seq', 6, true);
+SELECT pg_catalog.setval('public.language_language_id_seq', 6, true);
 
 
 --
 -- Name: payment_payment_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('payment_payment_id_seq', 32098, true);
+SELECT pg_catalog.setval('public.payment_payment_id_seq', 32098, true);
 
 
 --
 -- Name: rental_rental_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('rental_rental_id_seq', 16049, true);
+SELECT pg_catalog.setval('public.rental_rental_id_seq', 16049, true);
 
 
 --
 -- Name: staff_staff_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('staff_staff_id_seq', 2, true);
+SELECT pg_catalog.setval('public.staff_staff_id_seq', 2, true);
 
 
 --
 -- Name: store_store_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('store_store_id_seq', 2, true);
+SELECT pg_catalog.setval('public.store_store_id_seq', 2, true);
 
 
 --

--- a/pagila-schema.sql
+++ b/pagila-schema.sql
@@ -2,39 +2,25 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.1
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 11.3
+-- Dumped by pg_dump version 11.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
-SET search_path = public, pg_catalog;
 
 --
 -- Name: mpaa_rating; Type: TYPE; Schema: public; Owner: postgres
 --
 
-CREATE TYPE mpaa_rating AS ENUM (
+CREATE TYPE public.mpaa_rating AS ENUM (
     'G',
     'PG',
     'PG-13',
@@ -43,23 +29,23 @@ CREATE TYPE mpaa_rating AS ENUM (
 );
 
 
-ALTER TYPE mpaa_rating OWNER TO postgres;
+ALTER TYPE public.mpaa_rating OWNER TO postgres;
 
 --
 -- Name: year; Type: DOMAIN; Schema: public; Owner: postgres
 --
 
-CREATE DOMAIN year AS integer
+CREATE DOMAIN public.year AS integer
 	CONSTRAINT year_check CHECK (((VALUE >= 1901) AND (VALUE <= 2155)));
 
 
-ALTER DOMAIN year OWNER TO postgres;
+ALTER DOMAIN public.year OWNER TO postgres;
 
 --
 -- Name: _group_concat(text, text); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION _group_concat(text, text) RETURNS text
+CREATE FUNCTION public._group_concat(text, text) RETURNS text
     LANGUAGE sql IMMUTABLE
     AS $_$
 SELECT CASE
@@ -76,7 +62,7 @@ ALTER FUNCTION public._group_concat(text, text) OWNER TO postgres;
 -- Name: film_in_stock(integer, integer); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION film_in_stock(p_film_id integer, p_store_id integer, OUT p_film_count integer) RETURNS SETOF integer
+CREATE FUNCTION public.film_in_stock(p_film_id integer, p_store_id integer, OUT p_film_count integer) RETURNS SETOF integer
     LANGUAGE sql
     AS $_$
      SELECT inventory_id
@@ -93,7 +79,7 @@ ALTER FUNCTION public.film_in_stock(p_film_id integer, p_store_id integer, OUT p
 -- Name: film_not_in_stock(integer, integer); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION film_not_in_stock(p_film_id integer, p_store_id integer, OUT p_film_count integer) RETURNS SETOF integer
+CREATE FUNCTION public.film_not_in_stock(p_film_id integer, p_store_id integer, OUT p_film_count integer) RETURNS SETOF integer
     LANGUAGE sql
     AS $_$
     SELECT inventory_id
@@ -110,7 +96,7 @@ ALTER FUNCTION public.film_not_in_stock(p_film_id integer, p_store_id integer, O
 -- Name: get_customer_balance(integer, timestamp without time zone); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION get_customer_balance(p_customer_id integer, p_effective_date timestamp without time zone) RETURNS numeric
+CREATE FUNCTION public.get_customer_balance(p_customer_id integer, p_effective_date timestamp without time zone) RETURNS numeric
     LANGUAGE plpgsql
     AS $$
        --#OK, WE NEED TO CALCULATE THE CURRENT BALANCE GIVEN A CUSTOMER_ID AND A DATE
@@ -155,7 +141,7 @@ ALTER FUNCTION public.get_customer_balance(p_customer_id integer, p_effective_da
 -- Name: inventory_held_by_customer(integer); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION inventory_held_by_customer(p_inventory_id integer) RETURNS integer
+CREATE FUNCTION public.inventory_held_by_customer(p_inventory_id integer) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -177,7 +163,7 @@ ALTER FUNCTION public.inventory_held_by_customer(p_inventory_id integer) OWNER T
 -- Name: inventory_in_stock(integer); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION inventory_in_stock(p_inventory_id integer) RETURNS boolean
+CREATE FUNCTION public.inventory_in_stock(p_inventory_id integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -214,7 +200,7 @@ ALTER FUNCTION public.inventory_in_stock(p_inventory_id integer) OWNER TO postgr
 -- Name: last_day(timestamp without time zone); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION last_day(timestamp without time zone) RETURNS date
+CREATE FUNCTION public.last_day(timestamp without time zone) RETURNS date
     LANGUAGE sql IMMUTABLE STRICT
     AS $_$
   SELECT CASE
@@ -232,7 +218,7 @@ ALTER FUNCTION public.last_day(timestamp without time zone) OWNER TO postgres;
 -- Name: last_updated(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION last_updated() RETURNS trigger
+CREATE FUNCTION public.last_updated() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -247,7 +233,7 @@ ALTER FUNCTION public.last_updated() OWNER TO postgres;
 -- Name: payment_date_update_handler(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION payment_date_update_handler() RETURNS trigger
+CREATE FUNCTION public.payment_date_update_handler() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -266,7 +252,7 @@ ALTER FUNCTION public.payment_date_update_handler() OWNER TO postgres;
 -- Name: payment_id_change_handler(integer, integer, smallint, smallint, integer, numeric, timestamp with time zone); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION payment_id_change_handler(old_payment_id integer, new_payment_id integer, new_customer_id smallint, new_staff_id smallint, new_rental_id integer, new_amount numeric, new_payment_date timestamp with time zone) RETURNS void
+CREATE FUNCTION public.payment_id_change_handler(old_payment_id integer, new_payment_id integer, new_customer_id smallint, new_staff_id smallint, new_rental_id integer, new_amount numeric, new_payment_date timestamp with time zone) RETURNS void
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -296,7 +282,7 @@ ALTER FUNCTION public.payment_id_change_handler(old_payment_id integer, new_paym
 -- Name: customer_customer_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE customer_customer_id_seq
+CREATE SEQUENCE public.customer_customer_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -304,7 +290,7 @@ CREATE SEQUENCE customer_customer_id_seq
     CACHE 1;
 
 
-ALTER TABLE customer_customer_id_seq OWNER TO postgres;
+ALTER TABLE public.customer_customer_id_seq OWNER TO postgres;
 
 SET default_tablespace = '';
 
@@ -314,8 +300,8 @@ SET default_with_oids = false;
 -- Name: customer; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE customer (
-    customer_id integer DEFAULT nextval('customer_customer_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.customer (
+    customer_id integer DEFAULT nextval('public.customer_customer_id_seq'::regclass) NOT NULL,
     store_id smallint NOT NULL,
     first_name character varying(45) NOT NULL,
     last_name character varying(45) NOT NULL,
@@ -328,13 +314,13 @@ CREATE TABLE customer (
 );
 
 
-ALTER TABLE customer OWNER TO postgres;
+ALTER TABLE public.customer OWNER TO postgres;
 
 --
 -- Name: rewards_report(integer, numeric); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION rewards_report(min_monthly_purchases integer, min_dollar_amount_purchased numeric) RETURNS SETOF customer
+CREATE FUNCTION public.rewards_report(min_monthly_purchases integer, min_dollar_amount_purchased numeric) RETURNS SETOF public.customer
     LANGUAGE plpgsql SECURITY DEFINER
     AS $_$
 DECLARE
@@ -398,8 +384,8 @@ ALTER FUNCTION public.rewards_report(min_monthly_purchases integer, min_dollar_a
 -- Name: group_concat(text); Type: AGGREGATE; Schema: public; Owner: postgres
 --
 
-CREATE AGGREGATE group_concat(text) (
-    SFUNC = _group_concat,
+CREATE AGGREGATE public.group_concat(text) (
+    SFUNC = public._group_concat,
     STYPE = text
 );
 
@@ -410,7 +396,7 @@ ALTER AGGREGATE public.group_concat(text) OWNER TO postgres;
 -- Name: actor_actor_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE actor_actor_id_seq
+CREATE SEQUENCE public.actor_actor_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -418,27 +404,27 @@ CREATE SEQUENCE actor_actor_id_seq
     CACHE 1;
 
 
-ALTER TABLE actor_actor_id_seq OWNER TO postgres;
+ALTER TABLE public.actor_actor_id_seq OWNER TO postgres;
 
 --
 -- Name: actor; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE actor (
-    actor_id integer DEFAULT nextval('actor_actor_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.actor (
+    actor_id integer DEFAULT nextval('public.actor_actor_id_seq'::regclass) NOT NULL,
     first_name character varying(45) NOT NULL,
     last_name character varying(45) NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE actor OWNER TO postgres;
+ALTER TABLE public.actor OWNER TO postgres;
 
 --
 -- Name: category_category_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE category_category_id_seq
+CREATE SEQUENCE public.category_category_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -446,26 +432,26 @@ CREATE SEQUENCE category_category_id_seq
     CACHE 1;
 
 
-ALTER TABLE category_category_id_seq OWNER TO postgres;
+ALTER TABLE public.category_category_id_seq OWNER TO postgres;
 
 --
 -- Name: category; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE category (
-    category_id integer DEFAULT nextval('category_category_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.category (
+    category_id integer DEFAULT nextval('public.category_category_id_seq'::regclass) NOT NULL,
     name character varying(25) NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE category OWNER TO postgres;
+ALTER TABLE public.category OWNER TO postgres;
 
 --
 -- Name: film_film_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE film_film_id_seq
+CREATE SEQUENCE public.film_film_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -473,86 +459,86 @@ CREATE SEQUENCE film_film_id_seq
     CACHE 1;
 
 
-ALTER TABLE film_film_id_seq OWNER TO postgres;
+ALTER TABLE public.film_film_id_seq OWNER TO postgres;
 
 --
 -- Name: film; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE film (
-    film_id integer DEFAULT nextval('film_film_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.film (
+    film_id integer DEFAULT nextval('public.film_film_id_seq'::regclass) NOT NULL,
     title character varying(255) NOT NULL,
     description text,
-    release_year year,
+    release_year public.year,
     language_id smallint NOT NULL,
     original_language_id smallint,
     rental_duration smallint DEFAULT 3 NOT NULL,
     rental_rate numeric(4,2) DEFAULT 4.99 NOT NULL,
     length smallint,
     replacement_cost numeric(5,2) DEFAULT 19.99 NOT NULL,
-    rating mpaa_rating DEFAULT 'G'::mpaa_rating,
+    rating public.mpaa_rating DEFAULT 'G'::public.mpaa_rating,
     last_update timestamp without time zone DEFAULT now() NOT NULL,
     special_features text[],
     fulltext tsvector NOT NULL
 );
 
 
-ALTER TABLE film OWNER TO postgres;
+ALTER TABLE public.film OWNER TO postgres;
 
 --
 -- Name: film_actor; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE film_actor (
+CREATE TABLE public.film_actor (
     actor_id smallint NOT NULL,
     film_id smallint NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE film_actor OWNER TO postgres;
+ALTER TABLE public.film_actor OWNER TO postgres;
 
 --
 -- Name: film_category; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE film_category (
+CREATE TABLE public.film_category (
     film_id smallint NOT NULL,
     category_id smallint NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE film_category OWNER TO postgres;
+ALTER TABLE public.film_category OWNER TO postgres;
 
 --
 -- Name: actor_info; Type: VIEW; Schema: public; Owner: postgres
 --
 
-CREATE VIEW actor_info AS
+CREATE VIEW public.actor_info AS
  SELECT a.actor_id,
     a.first_name,
     a.last_name,
-    group_concat(DISTINCT (((c.name)::text || ': '::text) || ( SELECT group_concat((f.title)::text) AS group_concat
-           FROM ((film f
-             JOIN film_category fc_1 ON ((f.film_id = fc_1.film_id)))
-             JOIN film_actor fa_1 ON ((f.film_id = fa_1.film_id)))
+    public.group_concat(DISTINCT (((c.name)::text || ': '::text) || ( SELECT public.group_concat((f.title)::text) AS group_concat
+           FROM ((public.film f
+             JOIN public.film_category fc_1 ON ((f.film_id = fc_1.film_id)))
+             JOIN public.film_actor fa_1 ON ((f.film_id = fa_1.film_id)))
           WHERE ((fc_1.category_id = c.category_id) AND (fa_1.actor_id = a.actor_id))
           GROUP BY fa_1.actor_id))) AS film_info
-   FROM (((actor a
-     LEFT JOIN film_actor fa ON ((a.actor_id = fa.actor_id)))
-     LEFT JOIN film_category fc ON ((fa.film_id = fc.film_id)))
-     LEFT JOIN category c ON ((fc.category_id = c.category_id)))
+   FROM (((public.actor a
+     LEFT JOIN public.film_actor fa ON ((a.actor_id = fa.actor_id)))
+     LEFT JOIN public.film_category fc ON ((fa.film_id = fc.film_id)))
+     LEFT JOIN public.category c ON ((fc.category_id = c.category_id)))
   GROUP BY a.actor_id, a.first_name, a.last_name;
 
 
-ALTER TABLE actor_info OWNER TO postgres;
+ALTER TABLE public.actor_info OWNER TO postgres;
 
 --
 -- Name: address_address_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE address_address_id_seq
+CREATE SEQUENCE public.address_address_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -560,14 +546,14 @@ CREATE SEQUENCE address_address_id_seq
     CACHE 1;
 
 
-ALTER TABLE address_address_id_seq OWNER TO postgres;
+ALTER TABLE public.address_address_id_seq OWNER TO postgres;
 
 --
 -- Name: address; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE address (
-    address_id integer DEFAULT nextval('address_address_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.address (
+    address_id integer DEFAULT nextval('public.address_address_id_seq'::regclass) NOT NULL,
     address character varying(50) NOT NULL,
     address2 character varying(50),
     district character varying(20) NOT NULL,
@@ -578,13 +564,13 @@ CREATE TABLE address (
 );
 
 
-ALTER TABLE address OWNER TO postgres;
+ALTER TABLE public.address OWNER TO postgres;
 
 --
 -- Name: city_city_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE city_city_id_seq
+CREATE SEQUENCE public.city_city_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -592,27 +578,27 @@ CREATE SEQUENCE city_city_id_seq
     CACHE 1;
 
 
-ALTER TABLE city_city_id_seq OWNER TO postgres;
+ALTER TABLE public.city_city_id_seq OWNER TO postgres;
 
 --
 -- Name: city; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE city (
-    city_id integer DEFAULT nextval('city_city_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.city (
+    city_id integer DEFAULT nextval('public.city_city_id_seq'::regclass) NOT NULL,
     city character varying(50) NOT NULL,
     country_id smallint NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE city OWNER TO postgres;
+ALTER TABLE public.city OWNER TO postgres;
 
 --
 -- Name: country_country_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE country_country_id_seq
+CREATE SEQUENCE public.country_country_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -620,26 +606,26 @@ CREATE SEQUENCE country_country_id_seq
     CACHE 1;
 
 
-ALTER TABLE country_country_id_seq OWNER TO postgres;
+ALTER TABLE public.country_country_id_seq OWNER TO postgres;
 
 --
 -- Name: country; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE country (
-    country_id integer DEFAULT nextval('country_country_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.country (
+    country_id integer DEFAULT nextval('public.country_country_id_seq'::regclass) NOT NULL,
     country character varying(50) NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE country OWNER TO postgres;
+ALTER TABLE public.country OWNER TO postgres;
 
 --
 -- Name: customer_list; Type: VIEW; Schema: public; Owner: postgres
 --
 
-CREATE VIEW customer_list AS
+CREATE VIEW public.customer_list AS
  SELECT cu.customer_id AS id,
     (((cu.first_name)::text || ' '::text) || (cu.last_name)::text) AS name,
     a.address,
@@ -652,19 +638,19 @@ CREATE VIEW customer_list AS
             ELSE ''::text
         END AS notes,
     cu.store_id AS sid
-   FROM (((customer cu
-     JOIN address a ON ((cu.address_id = a.address_id)))
-     JOIN city ON ((a.city_id = city.city_id)))
-     JOIN country ON ((city.country_id = country.country_id)));
+   FROM (((public.customer cu
+     JOIN public.address a ON ((cu.address_id = a.address_id)))
+     JOIN public.city ON ((a.city_id = city.city_id)))
+     JOIN public.country ON ((city.country_id = country.country_id)));
 
 
-ALTER TABLE customer_list OWNER TO postgres;
+ALTER TABLE public.customer_list OWNER TO postgres;
 
 --
 -- Name: film_list; Type: VIEW; Schema: public; Owner: postgres
 --
 
-CREATE VIEW film_list AS
+CREATE VIEW public.film_list AS
  SELECT film.film_id AS fid,
     film.title,
     film.description,
@@ -672,22 +658,22 @@ CREATE VIEW film_list AS
     film.rental_rate AS price,
     film.length,
     film.rating,
-    group_concat((((actor.first_name)::text || ' '::text) || (actor.last_name)::text)) AS actors
-   FROM ((((category
-     LEFT JOIN film_category ON ((category.category_id = film_category.category_id)))
-     LEFT JOIN film ON ((film_category.film_id = film.film_id)))
-     JOIN film_actor ON ((film.film_id = film_actor.film_id)))
-     JOIN actor ON ((film_actor.actor_id = actor.actor_id)))
+    public.group_concat((((actor.first_name)::text || ' '::text) || (actor.last_name)::text)) AS actors
+   FROM ((((public.category
+     LEFT JOIN public.film_category ON ((category.category_id = film_category.category_id)))
+     LEFT JOIN public.film ON ((film_category.film_id = film.film_id)))
+     JOIN public.film_actor ON ((film.film_id = film_actor.film_id)))
+     JOIN public.actor ON ((film_actor.actor_id = actor.actor_id)))
   GROUP BY film.film_id, film.title, film.description, category.name, film.rental_rate, film.length, film.rating;
 
 
-ALTER TABLE film_list OWNER TO postgres;
+ALTER TABLE public.film_list OWNER TO postgres;
 
 --
 -- Name: inventory_inventory_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE inventory_inventory_id_seq
+CREATE SEQUENCE public.inventory_inventory_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -695,27 +681,27 @@ CREATE SEQUENCE inventory_inventory_id_seq
     CACHE 1;
 
 
-ALTER TABLE inventory_inventory_id_seq OWNER TO postgres;
+ALTER TABLE public.inventory_inventory_id_seq OWNER TO postgres;
 
 --
 -- Name: inventory; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE inventory (
-    inventory_id integer DEFAULT nextval('inventory_inventory_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.inventory (
+    inventory_id integer DEFAULT nextval('public.inventory_inventory_id_seq'::regclass) NOT NULL,
     film_id smallint NOT NULL,
     store_id smallint NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE inventory OWNER TO postgres;
+ALTER TABLE public.inventory OWNER TO postgres;
 
 --
 -- Name: language_language_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE language_language_id_seq
+CREATE SEQUENCE public.language_language_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -723,26 +709,26 @@ CREATE SEQUENCE language_language_id_seq
     CACHE 1;
 
 
-ALTER TABLE language_language_id_seq OWNER TO postgres;
+ALTER TABLE public.language_language_id_seq OWNER TO postgres;
 
 --
 -- Name: language; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE language (
-    language_id integer DEFAULT nextval('language_language_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.language (
+    language_id integer DEFAULT nextval('public.language_language_id_seq'::regclass) NOT NULL,
     name character(20) NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE language OWNER TO postgres;
+ALTER TABLE public.language OWNER TO postgres;
 
 --
 -- Name: nicer_but_slower_film_list; Type: VIEW; Schema: public; Owner: postgres
 --
 
-CREATE VIEW nicer_but_slower_film_list AS
+CREATE VIEW public.nicer_but_slower_film_list AS
  SELECT film.film_id AS fid,
     film.title,
     film.description,
@@ -750,22 +736,22 @@ CREATE VIEW nicer_but_slower_film_list AS
     film.rental_rate AS price,
     film.length,
     film.rating,
-    group_concat((((upper("substring"((actor.first_name)::text, 1, 1)) || lower("substring"((actor.first_name)::text, 2))) || upper("substring"((actor.last_name)::text, 1, 1))) || lower("substring"((actor.last_name)::text, 2)))) AS actors
-   FROM ((((category
-     LEFT JOIN film_category ON ((category.category_id = film_category.category_id)))
-     LEFT JOIN film ON ((film_category.film_id = film.film_id)))
-     JOIN film_actor ON ((film.film_id = film_actor.film_id)))
-     JOIN actor ON ((film_actor.actor_id = actor.actor_id)))
+    public.group_concat((((upper("substring"((actor.first_name)::text, 1, 1)) || lower("substring"((actor.first_name)::text, 2))) || upper("substring"((actor.last_name)::text, 1, 1))) || lower("substring"((actor.last_name)::text, 2)))) AS actors
+   FROM ((((public.category
+     LEFT JOIN public.film_category ON ((category.category_id = film_category.category_id)))
+     LEFT JOIN public.film ON ((film_category.film_id = film.film_id)))
+     JOIN public.film_actor ON ((film.film_id = film_actor.film_id)))
+     JOIN public.actor ON ((film_actor.actor_id = actor.actor_id)))
   GROUP BY film.film_id, film.title, film.description, category.name, film.rental_rate, film.length, film.rating;
 
 
-ALTER TABLE nicer_but_slower_film_list OWNER TO postgres;
+ALTER TABLE public.nicer_but_slower_film_list OWNER TO postgres;
 
 --
 -- Name: payment_payment_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE payment_payment_id_seq
+CREATE SEQUENCE public.payment_payment_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -773,14 +759,14 @@ CREATE SEQUENCE payment_payment_id_seq
     CACHE 1;
 
 
-ALTER TABLE payment_payment_id_seq OWNER TO postgres;
+ALTER TABLE public.payment_payment_id_seq OWNER TO postgres;
 
 --
 -- Name: payment; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment (
-    payment_id integer DEFAULT nextval('payment_payment_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.payment (
+    payment_id integer DEFAULT nextval('public.payment_payment_id_seq'::regclass) NOT NULL,
     customer_id smallint NOT NULL,
     staff_id smallint NOT NULL,
     rental_id integer NOT NULL,
@@ -790,73 +776,73 @@ CREATE TABLE payment (
 PARTITION BY RANGE (payment_date);
 
 
-ALTER TABLE payment OWNER TO postgres;
+ALTER TABLE public.payment OWNER TO postgres;
 
 --
 -- Name: payment_p2007_01; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_01 PARTITION OF payment
+CREATE TABLE public.payment_p2007_01 PARTITION OF public.payment
 FOR VALUES FROM ('2007-01-01 00:00:00') TO ('2007-02-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_01 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_01 OWNER TO postgres;
 
 --
 -- Name: payment_p2007_02; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_02 PARTITION OF payment
+CREATE TABLE public.payment_p2007_02 PARTITION OF public.payment
 FOR VALUES FROM ('2007-02-01 00:00:00') TO ('2007-03-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_02 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_02 OWNER TO postgres;
 
 --
 -- Name: payment_p2007_03; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_03 PARTITION OF payment
+CREATE TABLE public.payment_p2007_03 PARTITION OF public.payment
 FOR VALUES FROM ('2007-03-01 00:00:00') TO ('2007-04-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_03 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_03 OWNER TO postgres;
 
 --
 -- Name: payment_p2007_04; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_04 PARTITION OF payment
+CREATE TABLE public.payment_p2007_04 PARTITION OF public.payment
 FOR VALUES FROM ('2007-04-01 00:00:00') TO ('2007-05-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_04 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_04 OWNER TO postgres;
 
 --
 -- Name: payment_p2007_05; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_05 PARTITION OF payment
+CREATE TABLE public.payment_p2007_05 PARTITION OF public.payment
 FOR VALUES FROM ('2007-05-01 00:00:00') TO ('2007-06-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_05 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_05 OWNER TO postgres;
 
 --
 -- Name: payment_p2007_06; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE payment_p2007_06 PARTITION OF payment
+CREATE TABLE public.payment_p2007_06 PARTITION OF public.payment
 FOR VALUES FROM ('2007-06-01 00:00:00') TO ('2007-07-01 00:00:00');
 
 
-ALTER TABLE payment_p2007_06 OWNER TO postgres;
+ALTER TABLE public.payment_p2007_06 OWNER TO postgres;
 
 --
 -- Name: rental_rental_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE rental_rental_id_seq
+CREATE SEQUENCE public.rental_rental_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -864,14 +850,14 @@ CREATE SEQUENCE rental_rental_id_seq
     CACHE 1;
 
 
-ALTER TABLE rental_rental_id_seq OWNER TO postgres;
+ALTER TABLE public.rental_rental_id_seq OWNER TO postgres;
 
 --
 -- Name: rental; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE rental (
-    rental_id integer DEFAULT nextval('rental_rental_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.rental (
+    rental_id integer DEFAULT nextval('public.rental_rental_id_seq'::regclass) NOT NULL,
     rental_date timestamp without time zone NOT NULL,
     inventory_id integer NOT NULL,
     customer_id smallint NOT NULL,
@@ -881,13 +867,13 @@ CREATE TABLE rental (
 );
 
 
-ALTER TABLE rental OWNER TO postgres;
+ALTER TABLE public.rental OWNER TO postgres;
 
 --
 -- Name: staff_staff_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE staff_staff_id_seq
+CREATE SEQUENCE public.staff_staff_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -895,14 +881,14 @@ CREATE SEQUENCE staff_staff_id_seq
     CACHE 1;
 
 
-ALTER TABLE staff_staff_id_seq OWNER TO postgres;
+ALTER TABLE public.staff_staff_id_seq OWNER TO postgres;
 
 --
 -- Name: staff; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE staff (
-    staff_id integer DEFAULT nextval('staff_staff_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.staff (
+    staff_id integer DEFAULT nextval('public.staff_staff_id_seq'::regclass) NOT NULL,
     first_name character varying(45) NOT NULL,
     last_name character varying(45) NOT NULL,
     address_id smallint NOT NULL,
@@ -916,13 +902,13 @@ CREATE TABLE staff (
 );
 
 
-ALTER TABLE staff OWNER TO postgres;
+ALTER TABLE public.staff OWNER TO postgres;
 
 --
 -- Name: staff_list; Type: VIEW; Schema: public; Owner: postgres
 --
 
-CREATE VIEW staff_list AS
+CREATE VIEW public.staff_list AS
  SELECT s.staff_id AS id,
     (((s.first_name)::text || ' '::text) || (s.last_name)::text) AS name,
     a.address,
@@ -931,19 +917,19 @@ CREATE VIEW staff_list AS
     city.city,
     country.country,
     s.store_id AS sid
-   FROM (((staff s
-     JOIN address a ON ((s.address_id = a.address_id)))
-     JOIN city ON ((a.city_id = city.city_id)))
-     JOIN country ON ((city.country_id = country.country_id)));
+   FROM (((public.staff s
+     JOIN public.address a ON ((s.address_id = a.address_id)))
+     JOIN public.city ON ((a.city_id = city.city_id)))
+     JOIN public.country ON ((city.country_id = country.country_id)));
 
 
-ALTER TABLE staff_list OWNER TO postgres;
+ALTER TABLE public.staff_list OWNER TO postgres;
 
 --
 -- Name: store_store_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE store_store_id_seq
+CREATE SEQUENCE public.store_store_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -951,69 +937,69 @@ CREATE SEQUENCE store_store_id_seq
     CACHE 1;
 
 
-ALTER TABLE store_store_id_seq OWNER TO postgres;
+ALTER TABLE public.store_store_id_seq OWNER TO postgres;
 
 --
 -- Name: store; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE store (
-    store_id integer DEFAULT nextval('store_store_id_seq'::regclass) NOT NULL,
+CREATE TABLE public.store (
+    store_id integer DEFAULT nextval('public.store_store_id_seq'::regclass) NOT NULL,
     manager_staff_id smallint NOT NULL,
     address_id smallint NOT NULL,
     last_update timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
-ALTER TABLE store OWNER TO postgres;
+ALTER TABLE public.store OWNER TO postgres;
 
 --
 -- Name: payment_p2007_01 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_01 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_01 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: payment_p2007_02 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_02 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_02 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: payment_p2007_03 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_03 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_03 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: payment_p2007_04 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_04 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_04 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: payment_p2007_05 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_05 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_05 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: payment_p2007_06 payment_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_06 ALTER COLUMN payment_id SET DEFAULT nextval('payment_payment_id_seq'::regclass);
+ALTER TABLE ONLY public.payment_p2007_06 ALTER COLUMN payment_id SET DEFAULT nextval('public.payment_payment_id_seq'::regclass);
 
 
 --
 -- Name: actor actor_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY actor
+ALTER TABLE ONLY public.actor
     ADD CONSTRAINT actor_pkey PRIMARY KEY (actor_id);
 
 
@@ -1021,7 +1007,7 @@ ALTER TABLE ONLY actor
 -- Name: address address_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY address
+ALTER TABLE ONLY public.address
     ADD CONSTRAINT address_pkey PRIMARY KEY (address_id);
 
 
@@ -1029,7 +1015,7 @@ ALTER TABLE ONLY address
 -- Name: category category_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY category
+ALTER TABLE ONLY public.category
     ADD CONSTRAINT category_pkey PRIMARY KEY (category_id);
 
 
@@ -1037,7 +1023,7 @@ ALTER TABLE ONLY category
 -- Name: city city_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY city
+ALTER TABLE ONLY public.city
     ADD CONSTRAINT city_pkey PRIMARY KEY (city_id);
 
 
@@ -1045,7 +1031,7 @@ ALTER TABLE ONLY city
 -- Name: country country_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY country
+ALTER TABLE ONLY public.country
     ADD CONSTRAINT country_pkey PRIMARY KEY (country_id);
 
 
@@ -1053,7 +1039,7 @@ ALTER TABLE ONLY country
 -- Name: customer customer_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY customer
+ALTER TABLE ONLY public.customer
     ADD CONSTRAINT customer_pkey PRIMARY KEY (customer_id);
 
 
@@ -1061,7 +1047,7 @@ ALTER TABLE ONLY customer
 -- Name: film_actor film_actor_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_actor
+ALTER TABLE ONLY public.film_actor
     ADD CONSTRAINT film_actor_pkey PRIMARY KEY (actor_id, film_id);
 
 
@@ -1069,7 +1055,7 @@ ALTER TABLE ONLY film_actor
 -- Name: film_category film_category_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_category
+ALTER TABLE ONLY public.film_category
     ADD CONSTRAINT film_category_pkey PRIMARY KEY (film_id, category_id);
 
 
@@ -1077,7 +1063,7 @@ ALTER TABLE ONLY film_category
 -- Name: film film_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film
+ALTER TABLE ONLY public.film
     ADD CONSTRAINT film_pkey PRIMARY KEY (film_id);
 
 
@@ -1085,7 +1071,7 @@ ALTER TABLE ONLY film
 -- Name: payment_p2007_01 idx_pk_payment_p2007_01_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_01
+ALTER TABLE ONLY public.payment_p2007_01
     ADD CONSTRAINT idx_pk_payment_p2007_01_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1093,7 +1079,7 @@ ALTER TABLE ONLY payment_p2007_01
 -- Name: payment_p2007_02 idx_pk_payment_p2007_02_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_02
+ALTER TABLE ONLY public.payment_p2007_02
     ADD CONSTRAINT idx_pk_payment_p2007_02_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1101,7 +1087,7 @@ ALTER TABLE ONLY payment_p2007_02
 -- Name: payment_p2007_03 idx_pk_payment_p2007_03_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_03
+ALTER TABLE ONLY public.payment_p2007_03
     ADD CONSTRAINT idx_pk_payment_p2007_03_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1109,7 +1095,7 @@ ALTER TABLE ONLY payment_p2007_03
 -- Name: payment_p2007_04 idx_pk_payment_p2007_04_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_04
+ALTER TABLE ONLY public.payment_p2007_04
     ADD CONSTRAINT idx_pk_payment_p2007_04_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1117,7 +1103,7 @@ ALTER TABLE ONLY payment_p2007_04
 -- Name: payment_p2007_05 idx_pk_payment_p2007_05_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_05
+ALTER TABLE ONLY public.payment_p2007_05
     ADD CONSTRAINT idx_pk_payment_p2007_05_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1125,7 +1111,7 @@ ALTER TABLE ONLY payment_p2007_05
 -- Name: payment_p2007_06 idx_pk_payment_p2007_06_payment_id; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_06
+ALTER TABLE ONLY public.payment_p2007_06
     ADD CONSTRAINT idx_pk_payment_p2007_06_payment_id PRIMARY KEY (payment_id);
 
 
@@ -1133,7 +1119,7 @@ ALTER TABLE ONLY payment_p2007_06
 -- Name: inventory inventory_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY inventory
+ALTER TABLE ONLY public.inventory
     ADD CONSTRAINT inventory_pkey PRIMARY KEY (inventory_id);
 
 
@@ -1141,7 +1127,7 @@ ALTER TABLE ONLY inventory
 -- Name: language language_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY language
+ALTER TABLE ONLY public.language
     ADD CONSTRAINT language_pkey PRIMARY KEY (language_id);
 
 
@@ -1149,7 +1135,7 @@ ALTER TABLE ONLY language
 -- Name: rental rental_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY rental
+ALTER TABLE ONLY public.rental
     ADD CONSTRAINT rental_pkey PRIMARY KEY (rental_id);
 
 
@@ -1157,7 +1143,7 @@ ALTER TABLE ONLY rental
 -- Name: staff staff_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY staff
+ALTER TABLE ONLY public.staff
     ADD CONSTRAINT staff_pkey PRIMARY KEY (staff_id);
 
 
@@ -1165,7 +1151,7 @@ ALTER TABLE ONLY staff
 -- Name: store store_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY store
+ALTER TABLE ONLY public.store
     ADD CONSTRAINT store_pkey PRIMARY KEY (store_id);
 
 
@@ -1173,189 +1159,189 @@ ALTER TABLE ONLY store
 -- Name: film_fulltext_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX film_fulltext_idx ON film USING gist (fulltext);
+CREATE INDEX film_fulltext_idx ON public.film USING gist (fulltext);
 
 
 --
 -- Name: idx_actor_last_name; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_actor_last_name ON actor USING btree (last_name);
+CREATE INDEX idx_actor_last_name ON public.actor USING btree (last_name);
 
 
 --
 -- Name: idx_fk_address_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_address_id ON customer USING btree (address_id);
+CREATE INDEX idx_fk_address_id ON public.customer USING btree (address_id);
 
 
 --
 -- Name: idx_fk_city_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_city_id ON address USING btree (city_id);
+CREATE INDEX idx_fk_city_id ON public.address USING btree (city_id);
 
 
 --
 -- Name: idx_fk_country_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_country_id ON city USING btree (country_id);
+CREATE INDEX idx_fk_country_id ON public.city USING btree (country_id);
 
 
 --
 -- Name: idx_fk_film_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_film_id ON film_actor USING btree (film_id);
+CREATE INDEX idx_fk_film_id ON public.film_actor USING btree (film_id);
 
 
 --
 -- Name: idx_fk_inventory_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_inventory_id ON rental USING btree (inventory_id);
+CREATE INDEX idx_fk_inventory_id ON public.rental USING btree (inventory_id);
 
 
 --
 -- Name: idx_fk_language_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_language_id ON film USING btree (language_id);
+CREATE INDEX idx_fk_language_id ON public.film USING btree (language_id);
 
 
 --
 -- Name: idx_fk_original_language_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_original_language_id ON film USING btree (original_language_id);
+CREATE INDEX idx_fk_original_language_id ON public.film USING btree (original_language_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_01_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_01_customer_id ON payment_p2007_01 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_01_customer_id ON public.payment_p2007_01 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_01_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_01_staff_id ON payment_p2007_01 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_01_staff_id ON public.payment_p2007_01 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_02_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_02_customer_id ON payment_p2007_02 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_02_customer_id ON public.payment_p2007_02 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_02_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_02_staff_id ON payment_p2007_02 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_02_staff_id ON public.payment_p2007_02 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_03_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_03_customer_id ON payment_p2007_03 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_03_customer_id ON public.payment_p2007_03 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_03_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_03_staff_id ON payment_p2007_03 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_03_staff_id ON public.payment_p2007_03 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_04_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_04_customer_id ON payment_p2007_04 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_04_customer_id ON public.payment_p2007_04 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_04_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_04_staff_id ON payment_p2007_04 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_04_staff_id ON public.payment_p2007_04 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_05_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_05_customer_id ON payment_p2007_05 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_05_customer_id ON public.payment_p2007_05 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_05_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_05_staff_id ON payment_p2007_05 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_05_staff_id ON public.payment_p2007_05 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_06_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_06_customer_id ON payment_p2007_06 USING btree (customer_id);
+CREATE INDEX idx_fk_payment_p2007_06_customer_id ON public.payment_p2007_06 USING btree (customer_id);
 
 
 --
 -- Name: idx_fk_payment_p2007_06_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_payment_p2007_06_staff_id ON payment_p2007_06 USING btree (staff_id);
+CREATE INDEX idx_fk_payment_p2007_06_staff_id ON public.payment_p2007_06 USING btree (staff_id);
 
 
 --
 -- Name: idx_fk_store_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_fk_store_id ON customer USING btree (store_id);
+CREATE INDEX idx_fk_store_id ON public.customer USING btree (store_id);
 
 
 --
 -- Name: idx_last_name; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_last_name ON customer USING btree (last_name);
+CREATE INDEX idx_last_name ON public.customer USING btree (last_name);
 
 
 --
 -- Name: idx_store_id_film_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_store_id_film_id ON inventory USING btree (store_id, film_id);
+CREATE INDEX idx_store_id_film_id ON public.inventory USING btree (store_id, film_id);
 
 
 --
 -- Name: idx_title; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_title ON film USING btree (title);
+CREATE INDEX idx_title ON public.film USING btree (title);
 
 
 --
 -- Name: idx_unq_manager_staff_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE UNIQUE INDEX idx_unq_manager_staff_id ON store USING btree (manager_staff_id);
+CREATE UNIQUE INDEX idx_unq_manager_staff_id ON public.store USING btree (manager_staff_id);
 
 
 --
 -- Name: idx_unq_rental_rental_date_inventory_id_customer_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE UNIQUE INDEX idx_unq_rental_rental_date_inventory_id_customer_id ON rental USING btree (rental_date, inventory_id, customer_id);
+CREATE UNIQUE INDEX idx_unq_rental_rental_date_inventory_id_customer_id ON public.rental USING btree (rental_date, inventory_id, customer_id);
 
 
 --
@@ -1363,451 +1349,451 @@ CREATE UNIQUE INDEX idx_unq_rental_rental_date_inventory_id_customer_id ON renta
 --
 
 CREATE RULE payment_pk_update AS
-    ON UPDATE TO payment
-   WHERE (new.payment_id <> old.payment_id) DO INSTEAD  SELECT payment_id_change_handler(old.payment_id, new.payment_id, new.customer_id, new.staff_id, new.rental_id, new.amount, (new.payment_date)::timestamp with time zone) AS payment_id_change_handler;
+    ON UPDATE TO public.payment
+   WHERE (new.payment_id <> old.payment_id) DO INSTEAD  SELECT public.payment_id_change_handler(old.payment_id, new.payment_id, new.customer_id, new.staff_id, new.rental_id, new.amount, (new.payment_date)::timestamp with time zone) AS payment_id_change_handler;
 
 
 --
 -- Name: film film_fulltext_trigger; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER film_fulltext_trigger BEFORE INSERT OR UPDATE ON film FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('fulltext', 'pg_catalog.english', 'title', 'description');
+CREATE TRIGGER film_fulltext_trigger BEFORE INSERT OR UPDATE ON public.film FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('fulltext', 'pg_catalog.english', 'title', 'description');
 
 
 --
 -- Name: actor last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON actor FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.actor FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: address last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON address FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.address FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: category last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON category FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.category FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: city last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON city FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.city FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: country last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON country FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.country FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: customer last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON customer FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.customer FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: film last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON film FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.film FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: film_actor last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON film_actor FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.film_actor FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: film_category last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON film_category FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.film_category FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: inventory last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON inventory FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.inventory FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: language last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON language FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.language FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: rental last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON rental FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.rental FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: staff last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON staff FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.staff FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: store last_updated; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER last_updated BEFORE UPDATE ON store FOR EACH ROW EXECUTE PROCEDURE last_updated();
+CREATE TRIGGER last_updated BEFORE UPDATE ON public.store FOR EACH ROW EXECUTE PROCEDURE public.last_updated();
 
 
 --
 -- Name: payment_p2007_01 update_payment_date_p2007_01; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_01 BEFORE UPDATE ON payment_p2007_01 FOR EACH ROW WHEN (((new.payment_date < '2007-01-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-02-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_01 BEFORE UPDATE ON public.payment_p2007_01 FOR EACH ROW WHEN (((new.payment_date < '2007-01-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-02-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: payment_p2007_02 update_payment_date_p2007_02; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_02 BEFORE UPDATE ON payment_p2007_02 FOR EACH ROW WHEN (((new.payment_date < '2007-02-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-03-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_02 BEFORE UPDATE ON public.payment_p2007_02 FOR EACH ROW WHEN (((new.payment_date < '2007-02-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-03-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: payment_p2007_03 update_payment_date_p2007_03; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_03 BEFORE UPDATE ON payment_p2007_03 FOR EACH ROW WHEN (((new.payment_date < '2007-03-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-04-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_03 BEFORE UPDATE ON public.payment_p2007_03 FOR EACH ROW WHEN (((new.payment_date < '2007-03-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-04-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: payment_p2007_04 update_payment_date_p2007_04; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_04 BEFORE UPDATE ON payment_p2007_04 FOR EACH ROW WHEN (((new.payment_date < '2007-04-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-05-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_04 BEFORE UPDATE ON public.payment_p2007_04 FOR EACH ROW WHEN (((new.payment_date < '2007-04-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-05-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: payment_p2007_05 update_payment_date_p2007_05; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_05 BEFORE UPDATE ON payment_p2007_05 FOR EACH ROW WHEN (((new.payment_date < '2007-05-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-06-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_05 BEFORE UPDATE ON public.payment_p2007_05 FOR EACH ROW WHEN (((new.payment_date < '2007-05-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-06-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: payment_p2007_06 update_payment_date_p2007_06; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
-CREATE TRIGGER update_payment_date_p2007_06 BEFORE UPDATE ON payment_p2007_06 FOR EACH ROW WHEN (((new.payment_date < '2007-06-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-07-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE payment_date_update_handler();
+CREATE TRIGGER update_payment_date_p2007_06 BEFORE UPDATE ON public.payment_p2007_06 FOR EACH ROW WHEN (((new.payment_date < '2007-06-01 00:00:00'::timestamp without time zone) OR (new.payment_date >= '2007-07-01 00:00:00'::timestamp without time zone))) EXECUTE PROCEDURE public.payment_date_update_handler();
 
 
 --
 -- Name: address address_city_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY address
-    ADD CONSTRAINT address_city_id_fkey FOREIGN KEY (city_id) REFERENCES city(city_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.address
+    ADD CONSTRAINT address_city_id_fkey FOREIGN KEY (city_id) REFERENCES public.city(city_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: city city_country_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY city
-    ADD CONSTRAINT city_country_id_fkey FOREIGN KEY (country_id) REFERENCES country(country_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.city
+    ADD CONSTRAINT city_country_id_fkey FOREIGN KEY (country_id) REFERENCES public.country(country_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: customer customer_address_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY customer
-    ADD CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.customer
+    ADD CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: customer customer_store_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY customer
-    ADD CONSTRAINT customer_store_id_fkey FOREIGN KEY (store_id) REFERENCES store(store_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.customer
+    ADD CONSTRAINT customer_store_id_fkey FOREIGN KEY (store_id) REFERENCES public.store(store_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film_actor film_actor_actor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_actor
-    ADD CONSTRAINT film_actor_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES actor(actor_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film_actor
+    ADD CONSTRAINT film_actor_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES public.actor(actor_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film_actor film_actor_film_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_actor
-    ADD CONSTRAINT film_actor_film_id_fkey FOREIGN KEY (film_id) REFERENCES film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film_actor
+    ADD CONSTRAINT film_actor_film_id_fkey FOREIGN KEY (film_id) REFERENCES public.film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film_category film_category_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_category
-    ADD CONSTRAINT film_category_category_id_fkey FOREIGN KEY (category_id) REFERENCES category(category_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film_category
+    ADD CONSTRAINT film_category_category_id_fkey FOREIGN KEY (category_id) REFERENCES public.category(category_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film_category film_category_film_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film_category
-    ADD CONSTRAINT film_category_film_id_fkey FOREIGN KEY (film_id) REFERENCES film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film_category
+    ADD CONSTRAINT film_category_film_id_fkey FOREIGN KEY (film_id) REFERENCES public.film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film film_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film
-    ADD CONSTRAINT film_language_id_fkey FOREIGN KEY (language_id) REFERENCES language(language_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film
+    ADD CONSTRAINT film_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(language_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: film film_original_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY film
-    ADD CONSTRAINT film_original_language_id_fkey FOREIGN KEY (original_language_id) REFERENCES language(language_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.film
+    ADD CONSTRAINT film_original_language_id_fkey FOREIGN KEY (original_language_id) REFERENCES public.language(language_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: inventory inventory_film_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY inventory
-    ADD CONSTRAINT inventory_film_id_fkey FOREIGN KEY (film_id) REFERENCES film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.inventory
+    ADD CONSTRAINT inventory_film_id_fkey FOREIGN KEY (film_id) REFERENCES public.film(film_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: inventory inventory_store_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY inventory
-    ADD CONSTRAINT inventory_store_id_fkey FOREIGN KEY (store_id) REFERENCES store(store_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.inventory
+    ADD CONSTRAINT inventory_store_id_fkey FOREIGN KEY (store_id) REFERENCES public.store(store_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: payment_p2007_01 payment_p2007_01_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_01
-    ADD CONSTRAINT payment_p2007_01_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_01
+    ADD CONSTRAINT payment_p2007_01_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_01 payment_p2007_01_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_01
-    ADD CONSTRAINT payment_p2007_01_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_01
+    ADD CONSTRAINT payment_p2007_01_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_01 payment_p2007_01_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_01
-    ADD CONSTRAINT payment_p2007_01_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_01
+    ADD CONSTRAINT payment_p2007_01_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: payment_p2007_02 payment_p2007_02_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_02
-    ADD CONSTRAINT payment_p2007_02_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_02
+    ADD CONSTRAINT payment_p2007_02_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_02 payment_p2007_02_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_02
-    ADD CONSTRAINT payment_p2007_02_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_02
+    ADD CONSTRAINT payment_p2007_02_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_02 payment_p2007_02_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_02
-    ADD CONSTRAINT payment_p2007_02_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_02
+    ADD CONSTRAINT payment_p2007_02_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: payment_p2007_03 payment_p2007_03_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_03
-    ADD CONSTRAINT payment_p2007_03_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_03
+    ADD CONSTRAINT payment_p2007_03_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_03 payment_p2007_03_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_03
-    ADD CONSTRAINT payment_p2007_03_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_03
+    ADD CONSTRAINT payment_p2007_03_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_03 payment_p2007_03_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_03
-    ADD CONSTRAINT payment_p2007_03_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_03
+    ADD CONSTRAINT payment_p2007_03_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: payment_p2007_04 payment_p2007_04_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_04
-    ADD CONSTRAINT payment_p2007_04_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_04
+    ADD CONSTRAINT payment_p2007_04_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_04 payment_p2007_04_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_04
-    ADD CONSTRAINT payment_p2007_04_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_04
+    ADD CONSTRAINT payment_p2007_04_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_04 payment_p2007_04_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_04
-    ADD CONSTRAINT payment_p2007_04_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_04
+    ADD CONSTRAINT payment_p2007_04_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: payment_p2007_05 payment_p2007_05_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_05
-    ADD CONSTRAINT payment_p2007_05_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_05
+    ADD CONSTRAINT payment_p2007_05_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_05 payment_p2007_05_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_05
-    ADD CONSTRAINT payment_p2007_05_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_05
+    ADD CONSTRAINT payment_p2007_05_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_05 payment_p2007_05_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_05
-    ADD CONSTRAINT payment_p2007_05_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_05
+    ADD CONSTRAINT payment_p2007_05_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: payment_p2007_06 payment_p2007_06_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_06
-    ADD CONSTRAINT payment_p2007_06_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id);
+ALTER TABLE ONLY public.payment_p2007_06
+    ADD CONSTRAINT payment_p2007_06_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id);
 
 
 --
 -- Name: payment_p2007_06 payment_p2007_06_rental_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_06
-    ADD CONSTRAINT payment_p2007_06_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES rental(rental_id);
+ALTER TABLE ONLY public.payment_p2007_06
+    ADD CONSTRAINT payment_p2007_06_rental_id_fkey FOREIGN KEY (rental_id) REFERENCES public.rental(rental_id);
 
 
 --
 -- Name: payment_p2007_06 payment_p2007_06_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY payment_p2007_06
-    ADD CONSTRAINT payment_p2007_06_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id);
+ALTER TABLE ONLY public.payment_p2007_06
+    ADD CONSTRAINT payment_p2007_06_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id);
 
 
 --
 -- Name: rental rental_customer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY rental
-    ADD CONSTRAINT rental_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customer(customer_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.rental
+    ADD CONSTRAINT rental_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customer(customer_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: rental rental_inventory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY rental
-    ADD CONSTRAINT rental_inventory_id_fkey FOREIGN KEY (inventory_id) REFERENCES inventory(inventory_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.rental
+    ADD CONSTRAINT rental_inventory_id_fkey FOREIGN KEY (inventory_id) REFERENCES public.inventory(inventory_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: rental rental_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY rental
-    ADD CONSTRAINT rental_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES staff(staff_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.rental
+    ADD CONSTRAINT rental_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staff(staff_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: staff staff_address_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY staff
-    ADD CONSTRAINT staff_address_id_fkey FOREIGN KEY (address_id) REFERENCES address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.staff
+    ADD CONSTRAINT staff_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: staff staff_store_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY staff
-    ADD CONSTRAINT staff_store_id_fkey FOREIGN KEY (store_id) REFERENCES store(store_id);
+ALTER TABLE ONLY public.staff
+    ADD CONSTRAINT staff_store_id_fkey FOREIGN KEY (store_id) REFERENCES public.store(store_id);
 
 
 --
 -- Name: store store_address_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY store
-    ADD CONSTRAINT store_address_id_fkey FOREIGN KEY (address_id) REFERENCES address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.store
+    ADD CONSTRAINT store_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
 -- Name: store store_manager_staff_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY store
-    ADD CONSTRAINT store_manager_staff_id_fkey FOREIGN KEY (manager_staff_id) REFERENCES staff(staff_id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.store
+    ADD CONSTRAINT store_manager_staff_id_fkey FOREIGN KEY (manager_staff_id) REFERENCES public.staff(staff_id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --


### PR DESCRIPTION
Note: As of Postgres 10.3, pg_dump now forces schema qualification on all
objects, so these diffs are more verbose than most previous version. I've
committed this seperately to better clarify changes specific to pg11 vs
changes forced on us by the upstream change in how pg_dump works. At this
point, this schema is meant to match the schema from the pagila 10 release.